### PR TITLE
fix/delete-variable-env-panther

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,4 +3,3 @@ KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 DATABASE_URL=mysql://root:root@fastrackOctobreBack_sql:3306/fastrackOctobreBack_test
-PANTHER_APP_ENV=panther


### PR DESCRIPTION
suppression de la variable d'environnement relative à l'utilisation de Panther car non utilisé sur le projet.