### PR TITLE
fix/partner-list REST

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,5 +1,5 @@
 api_list_partner:
-  path: /api/partner/list
+  path: /api/partner
   controller: App\Controller\PartnerController::list
   methods: GET
 

--- a/tests/Large/Controller/PartnerControllerTest.php
+++ b/tests/Large/Controller/PartnerControllerTest.php
@@ -18,7 +18,7 @@ class PartnerControllerTest extends WebTestCase
 
     public function testList()
     {
-        $this->client->request('GET', '/api/partner/list');
+        $this->client->request('GET', '/api/partner');
 
         $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         $this->assertJson($this->client->getResponse()->getContent());


### PR DESCRIPTION
Changement du nom de la route api/partner/list en api/partner pour respecter les règles de l'api REST